### PR TITLE
Add regolo-ts-client: TypeScript SDK and CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 ## SDK
 
 * [python-client](https://github.com/regolo-ai/python-client) - A simple Python client for interacting with Regolo.ai's LLM-based API by CLI or code.
+* [regolo-ts-client](https://github.com/matteo-brandolino/regolo-ts-client) - A TypeScript SDK and CLI for interacting with Regolo.ai's API — chat, embeddings, image generation, audio transcription, and reranking.
 
 ## Official Integrations
 


### PR DESCRIPTION
## What

Adds [regolo-ts-client](https://github.com/matteo-brandolino/regolo-ts-client) to the **SDK** section — a TypeScript counterpart to the official Python client.

## Details

It's a pnpm monorepo with two packages:

- **`regolo-client`** (SDK) — published on npm, covers the full API surface: chat with streaming, embeddings, image generation, audio transcription, and reranking
- **`@regolo/cli`** — full-featured CLI built with oclif, mirrors the Python CLI commands

The SDK has unit tests (Vitest) and CI via GitHub Actions.